### PR TITLE
Proxy auth の実装

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -22,6 +22,6 @@ WORKDIR /work
 COPY --from=base /work .
 RUN npm run build
 
-FROM joseluisq/static-web-server:2 AS prod
+FROM ghcr.io/static-web-server/static-web-server:2 AS prod
 
 COPY --from=builder /work/dist /public

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,7 @@ services:
       - /work/node_modules
     labels:
       "traefik.http.routers.client.rule": Host(`dev.local.trapti.tech`)
+      "traefik.http.routers.client.middlewares": tfa@docker
       "traefik.http.routers.client.service": client
       "traefik.http.services.client.loadbalancer.server.port": "5173" # target: dev
       # "traefik.http.services.client.loadbalancer.server.port": "80" # target: prod
@@ -24,6 +25,7 @@ services:
       MARIADB_DATABASE: dev
     labels:
       "traefik.http.routers.server.rule": Host(`dev.local.trapti.tech`) && PathPrefix(`/api`)
+      "traefik.http.routers.server.middlewares": tfa@docker
       "traefik.http.routers.server.service": server
       "traefik.http.services.server.loadbalancer.server.port": "8080"
 
@@ -37,6 +39,17 @@ services:
     volumes:
       - ./data/mysql:/var/lib/mysql
 
+  auth:
+    image: ghcr.io/traptitech/traefik-forward-auth:3.2.1
+    command:
+      - -config=/config.yaml
+    volumes:
+      - ./dev/traefik-forward-auth.yaml:/config.yaml:ro
+    labels:
+      "traefik.http.routers.tfa.rule": Host(`auth.local.trapti.tech`)
+      "traefik.http.routers.tfa.service": tfa
+      "traefik.http.services.tfa.loadbalancer.server.port": "4181"
+
   traefik:
     image: traefik:3.0
     command:
@@ -45,3 +58,6 @@ services:
       - 80:80
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      "traefik.http.middlewares.tfa.forwardauth.address": http://auth:4181/
+      "traefik.http.middlewares.tfa.forwardauth.authResponseHeaders": X-Forwarded-User

--- a/dev/traefik-forward-auth.yaml
+++ b/dev/traefik-forward-auth.yaml
@@ -1,0 +1,28 @@
+secret: dev-secret
+log-level: info
+
+provider: oidc
+insecure-cookie: true
+
+auth-host: auth.local.trapti.tech
+cookie-domains: local.trapti.tech
+cookie-name: _forward_auth
+# 2 weeks
+lifetime: 1209600
+info-fields:
+  - name
+
+providers:
+  oidc:
+    # Only need the "openid" scope for now
+    scopes: ""
+    issuer-url: https://q.trap.jp
+    client-id: "fwa5rtIuIgviI0RvnumqSUChKcGFZwcxwzih"
+    # NOTE: public client does not necessarily need the secret
+    client-secret: "KwjZxBS2PZJtCIK5oAKe9PpOEvMJ6uVk77iy"
+    prompt: none
+
+headers:
+  h-1:
+    name: X-Forwarded-User
+    source: name

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -16,6 +16,17 @@ func NewHandlers(repo *Repository) *Handlers {
 	return &Handlers{repo: repo}
 }
 
+type getMeResponse struct {
+	ID string `json:"id"`
+}
+
+func (h *Handlers) GetMe(c echo.Context) error {
+	id := c.Request().Header.Get("X-Forwarded-User")
+	return c.JSON(http.StatusOK, &getMeResponse{
+		ID: id,
+	})
+}
+
 type getUserResponse struct {
 	Groups []string `json:"groups"`
 }

--- a/server/main.go
+++ b/server/main.go
@@ -36,6 +36,7 @@ func main() {
 	e := echo.New()
 	api := e.Group("/api")
 	{
+		api.GET("/users/me", h.GetMe)
 		api.GET("/users/:id", h.GetUser)
 		api.GET("/users/:id/random", h.GetUserRandomConnection)
 		api.GET("/users/:id/connections", h.GetUserConnections)


### PR DESCRIPTION
ローカルで開発用の認証機構を作りました

NeoShowcaseでのプロキシ認証と同じ方式です（プロキシ先へは、HTTPヘッダー `X-Forwarded-Auth` が渡される）
https://doc.traefik.io/traefik/middlewares/http/forwardauth/